### PR TITLE
Two small updates about keywords' format.

### DIFF
--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -93,7 +93,8 @@
 
 % CJK character support
 \RequirePackage{fontspec,xltxtra,xunicode}
-\RequirePackage[slantfont,boldfont,CJKnumber]{xeCJK}
+\RequirePackage[slantfont,boldfont]{xeCJK}
+\RequirePackage{CJKnumb}
 \punctstyle{hangmobanjiao}
 
 % Padding
@@ -521,8 +522,8 @@
 
         \mbox{}
 
-        {\wuhao \noindent
-            {\bf 关键词}：
+        {\xiaosi \noindent
+            {\bf 关\ \ 键\ \ 词}：
         \xjtu@ckeywords}
         \clearpage
     }
@@ -548,7 +549,7 @@
 
         \mbox{ }
 
-        {\wuhao\noindent
+        {\xiaosi \noindent
             {\bf KEY WORDS: }
             \xjtu@ekeywords
         }


### PR DESCRIPTION
1) In new undergraduate thesis template,  "关键词" and “KEYWORDS” are "xiaosi" now. And "关键词" is changed to “关 键 词”;
2) CJKnumber option of xeCJK is now deprecated and replaced by "\RequirePackage{CJKnumb}".