### PR TITLE
fix 6 features in bachelor's thesis

### DIFF
--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -91,7 +91,7 @@
 \setenumerate[2]{\qquad(1),itemindent=\parindent,listparindent=\parindent,itemsep=0ex,partopsep=0pt,parsep=0ex,topsep=0\baselineskip}
 \RequirePackage{pdfpages}
 \RequirePackage{hanging}
-\RequirePackage{color}
+\RequirePackage{xcolor}
 
 % CJK character support
 \RequirePackage{fontspec,xltxtra,xunicode}
@@ -370,12 +370,12 @@
 
 % Section titles, style
 \titleformat{\chapter}[block]{\sanhao}{}{1em}{\begin{center}}[\end{center}]
-\titlespacing{\chapter}{0em}{0\baselineskip}{1\baselineskip}
-\titleformat{\section}[hang]{\xiaosan}{\thesection}{1em}{}
+\titlespacing{\chapter}{0em}{-1\baselineskip}{0.1\baselineskip}
+\titleformat{\section}[hang]{\xiaosan}{\thesection}{0.8em}{}
 \titlespacing{\section}{0em}{1\baselineskip}{0.5\baselineskip}
-\titleformat{\subsection}{\sihao}{\thesubsection}{1em}{}
+\titleformat{\subsection}{\sihao}{\ \ \thesubsection}{0.8em}{}
 \titlespacing{\subsection}{2em}{0.5\baselineskip}{0\baselineskip}
-\titleformat{\subsubsection}{}{\arabic{subsubsection})~}{1em}{}
+\titleformat{\subsubsection}{}{\qquad\qquad\arabic{subsubsection})~}{0.8em}{}
 \titlespacing{\subsubsection}{2em}{0.2\baselineskip}{0\baselineskip}
 \renewcommand{\l@chapter}{\@dottedtocline{1}{0em}{1.5em}}
 
@@ -527,21 +527,19 @@
             \vskip 1.5cm
             \CJKfamily{hei} \sanhao
                 \hangpara{4em}{1}
-                {\color{red} 题 \quad 目 \CJKunderline*{\hfill \xjtu@ctitle \hfill}}
+                {\color{red} 题 \quad 目 \textbf{\CJKunderline*{ \hfill  \xjtu@ctitle \hfill}}}
             \vskip 2cm
-        \textcolor{red}{
             \begin{spacing}{1.8}{\CJKfamily{hei} \sanhao
-                \CJKunderline*{ \hfill \xjtu@ccollege \hfill}学院
-                \CJKunderline*{ \hfill \xjtu@cmajor \hfill}专业
-                \CJKunderline*{ \hfill \xjtu@cclass \hfill}班 \\
-                学生姓名 \CJKunderline* {\hfill {\xjtu@cauthor} \hfill} \\
-                学\qquad 号 \CJKunderline* {\hfill {\xjtu@stunum} \hfill} \\
-                指导教师 \CJKunderline* {\hfill {\xjtu@csupervisor} \hfill} \\
-                设计所在单位 \CJKunderline* {\hfill {\xjtu@corgnization} \hfill} \\
+                    \textbf{\color{red}\CJKunderline*{ \hfill \xjtu@ccollege \hfill}}\color{red} 学院
+                    \textbf{\CJKunderline*{ \hfill \xjtu@cmajor \hfill}}\color{red} 专业
+                    \textbf{\CJKunderline*{ \hfill \xjtu@cclass \hfill}}\color{red} 班 \\
+                    \color{red} 学生姓名 \textbf{\CJKunderline* {\hfill {\xjtu@cauthor} \hfill}} \\
+                    \color{red} 学\qquad 号 \textbf{\CJKunderline* {\hfill {\xjtu@stunum} \hfill}} \\
+                    \color{red} 指导教师 \textbf{\CJKunderline* {\hfill {\xjtu@csupervisor} \hfill}} \\
+                    \color{red} 设计所在单位 \textbf{\CJKunderline* {\hfill {\xjtu@corgnization} \hfill}} \\
             }
-            \sanhao \center {\bf \xjtu@cproddate}
+            \color{red} \sanhao \center {\bf \xjtu@cproddate}
             \end{spacing}
-        }
 
         \end{flushleft}
 
@@ -616,7 +614,7 @@
             \pagestyle{plain}
         \fi
         \pagenumbering{arabic}
-        \titleformat{\chapter}[block]{\sanhao}{}{0em}{\begin{center}\thechapter\quad}[\end{center}]
+        \titleformat{\chapter}[block]{\sanhao}{}{0em}{\begin{center}\thechapter\quad\ \ }[\end{center}]
         \xjtu@inmainbodytrue
     }
     \renewcommand\xjtuendcontent{
@@ -968,6 +966,6 @@
 %\renewcommand{\l@chapter}{\@dottedtocline{1}{0em}{1.5em}}
 %\makeatother
 
-\titlecontents{chapter}[0em]{}{\thecontentslabel\quad}{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}
-\titlecontents{section}[1em]{}{\thecontentslabel\quad}{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}
-\titlecontents{subsection}[2em]{}{\thecontentslabel\quad}{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}
+\titlecontents{chapter}[0em]{}{\thecontentslabel\ \ }{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}
+\titlecontents{section}[1em]{}{\thecontentslabel\ \ }{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}
+\titlecontents{subsection}[2em]{}{\thecontentslabel\ \ }{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}

--- a/solutions/bachelor.tex
+++ b/solutions/bachelor.tex
@@ -42,6 +42,7 @@
     \input{pages/meta.tex}
 
     \xjtuchead
+    \setcounter{page}{5} % 为任务书和其他内容留空间
     \xjtucinfopage
     \xjtueinfopage
     \xjtutoc
@@ -62,6 +63,10 @@
 
     \xjtuendcontent
 
+    \xjtuspchapter{致谢}{致\qquad 谢}
+
+        \input{pages/acknowledgements.tex}
+
     % 将你要引用的文献的 BibTeX 放入 bibliography.bib
     \xjtubib{bibliography}
 
@@ -71,9 +76,6 @@
 
     \xjtuendappendix
 
-    \xjtuspchapter{致谢}{致\qquad 谢}
-
-        \input{pages/acknowledgements.tex}
 
 \end{document}
 

--- a/solutions/pages/meta.tex
+++ b/solutions/pages/meta.tex
@@ -52,8 +52,8 @@
 % 研究生的应首先从《汉语主题词表》中摘选
 \ckeywords{}
 
-% 提交日期，本科生不需要
-\cproddate{\the\year 年\the\month 月}
+% 提交日期
+\cproddate{{\color{black}\the\year} 年\ {\color{black}\the\month} 月}
 
 % 论文类型，中文，本科生不需要
 % 从理论研究、应用基础、应用研究、研究报告、软件开发、设计报告、案例分析、调研报告、其它中选择


### PR DESCRIPTION
感谢作者提供的模板，我基于此模板撰写的论文成功通过了我校软件学院的21届本科毕业设计答辩。为了和学校所提供的模板相契合，我在本仓库的基础上进行了6项修改，想要提交pr以帮助后人。

测试环境：Texlive 2021.58710-2

1. 重新修改了封面颜色布局(学校要求所有填入字体为黑色粗体)
根据学校要求，封面中的所有填入字需为黑色粗体。修改后的效果如下图所示
![图片](https://user-images.githubusercontent.com/55623213/133535141-e650f7e0-508b-4d21-a5b4-f7c593b8e74f.png)

2. 修改了章节标题与顶部的距离
3. 修改了正文中标题的缩进
本模板原有的章节标题与顶部距离与学校提供模板有一定差距，标题缩进也与学校模板有些不同，经修改后的效果如下图所示(左为latex模板编译结果，右为学校提供word模板)
![图片](https://user-images.githubusercontent.com/55623213/133535516-579dbfe9-27ea-4cbd-a8f4-6a7b60f31ad4.png)

4. 修改了目录中标题的缩进
经修改后的效果如下图所示(左为latex模板编译结果，右为学校提供word模板)
![图片](https://user-images.githubusercontent.com/55623213/133535712-390297e5-ca00-40dd-849c-7eb2ac5808dc.png)

5. 将摘要页设为第5页，为任务书等其他内容预留空间
学校提供的模板中中文摘要位于第5页，前4页为标好页码的任务书、考核评议书、评审意见书、答辩结果书等需要自行从系统中下载的内容，因此中文摘要应开始与第5页。

6. 修改了致谢，参考文献，附录的顺序(学校模板给出的顺序为：致谢->参考文献->附录)

本人成功使用此模板通过了软件学院的本科毕业设计答辩，答辩老师没有对我的格式提出异议。
