### PR TITLE
Updated spacing and footnote style conforming to the latest bs word template.

### DIFF
--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -194,7 +194,7 @@
 \thu@define@fontsize{bahao}{5bp}
 \renewcommand\normalsize{%
   %下面这一行必须以百分号结尾，否则header会有一个向右的微小偏移。
-  \@setfontsize\normalsize{12bp}{20bp}%
+  \@setfontsize\normalsize{12bp}{15.6bp}%
   \abovedisplayskip=10bp \@plus 2bp \@minus 2bp
   \abovedisplayshortskip=10bp \@plus 2bp \@minus 2bp
   \belowdisplayskip=\abovedisplayskip
@@ -274,11 +274,11 @@
 % http://tex.stackexchange.com/questions/133264/circled-footnote-symbols-with-pifont-showing-arrows-instead-of-circled-numbers
 \newcommand*\circled[1]{
     \tikz[baseline=(char.base)]
-    \node[shape=circle,draw,inner sep=0.5pt,minimum size=8pt] (char) {#1};
+    \node[shape=circle,draw,inner sep=0.2pt,minimum size=4pt] (char) {\tiny #1};
 }
 \renewcommand\thefootnote{\protect\circled{\arabic{footnote}}}
 \renewcommand\@makefntext[1]{
-    \noindent\makebox[0pt][r]{\@thefnmark}#1
+    \noindent\raisebox{2ex-\height}{\@thefnmark}\onehalfspacing #1 \vspace*{1ex}
 }
 
 \thu@define@term{type}
@@ -494,9 +494,9 @@
       \linespread{1.2} \selectfont
     \fi
 
-    \renewcommand\footnoterule{\vspace*{-3pt}% eggache!
-        \hrule width 0.25\textwidth height 0.4pt
-            \vspace*{2.6pt}}
+    \renewcommand\footnoterule{\vspace*{2ex}% eggache!
+        \rule{0.25\paperwidth}{0.4pt}
+            \vspace*{1ex}}
 
     \fancypagestyle{plain}{%
       \fancyhf{}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -94,6 +94,10 @@
 \RequirePackage{xcolor}
 \RequirePackage{gbt7714}
 
+% Add spacing before a table
+\RequirePackage{etoolbox}
+\AtBeginEnvironment{table}{\vspace{10pt}}
+
 % CJK character support
 \RequirePackage{fontspec,xltxtra,xunicode}
 \RequirePackage[slantfont,boldfont]{xeCJK}


### PR DESCRIPTION
This is what footnotes in the latest XJTU bachelor's thesis Word template look like:

![bsthesisfootnoteword](https://github.com/Aetf/xjtuthesis/assets/30975570/bd9da666-9c1e-47bc-a2d7-fac246f453a9)

I made some YOLO adaptation that makes the visual behavior similar, precise lengths not measured.

Also, the text spacing is updated. It's more compact today in 2023.