### PR TITLE
Add a option to set typesetting method & Minor format changes in Bachelor‘s template

### DIFF
--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -497,6 +497,7 @@
 
 \ifxjtu@bachelor
     \titleformat{\subsection}{\sihao}{\thesubsection}{0.8em}{}
+    \titlespacing{\chapter}{0em}{-1.3\baselineskip}{0.2\baselineskip}
     \ifxjtu@bigskip
       \linespread{1.5} \selectfont
     \else

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -45,6 +45,7 @@
 \newif\ifxjtu@colorlinks\xjtu@colorlinksfalse
 \newif\ifxjtu@compact   \xjtu@compactfalse
 \newif\ifxjtu@content	  \xjtu@contentfalse
+\newif\ifxjtu@autolineskip	  \xjtu@autolineskipfalse
 
 \DeclareOption{bachelor}    {\xjtu@bachelortrue}
 \DeclareOption{master}      {\xjtu@mastertrue}
@@ -55,6 +56,7 @@
 \DeclareOption{pdflinks}    {\xjtu@pdflinkstrue}
 \DeclareOption{colorlinks}  {\xjtu@colorlinkstrue}
 \DeclareOption{compact}     {\xjtu@compacttrue}
+\DeclareOption{autolineskip}     {\xjtu@autolineskiptrue}
 
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{book}}
 
@@ -247,6 +249,10 @@
         \def\CJKmove{\let\CJKsymbol\CJKmovesymbol \let\CJKpunctsymbol\CJKsymbol}
     \setCJKfamilyfont{hei}{Source Han Sans CN}
   \fi
+\fi
+%auto lineskip or strictly follow the set line skip.
+\ifxjtu@autolineskip\else
+    \raggedbottom
 \fi
 
 \def\thu@define@term#1{
@@ -499,7 +505,7 @@
     %根据本科模板重写节标题格式且不影响硕博格式
     \titleformat{\subsection}{\sihao}{\thesubsection}{0.8em}{}
     \titleformat{\subsubsection}{}{\arabic{subsubsection})~}{0.8em}{}
-    \titlespacing{\chapter}{0em}{-1.3\baselineskip}{0.2\baselineskip}
+    \titlespacing{\chapter}{0em}{-1.3\baselineskip}{0.3\baselineskip}
     \ifxjtu@bigskip
       \linespread{1.5} \selectfont
     \else

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -515,7 +515,7 @@
                         \fi}
       \fancyfoot[OR,EL]{\xiaowu ~\thepage~}
       \renewcommand{\headrulewidth}{\if@mainmatter 0.5pt\else 0pt \fi}
-      \renewcommand{\headrule}{\hrule \@height \headrulewidth \@width \headwidth \vskip .5pt
+      \renewcommand{\headrule}{\vskip 3.5pt \hrule \@height \headrulewidth \@width \headwidth \vskip .5pt
       \hrule \@height \headrulewidth \@width \headwidth \vskip -\headrulewidth}
 
     }

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -496,7 +496,9 @@
 \fi
 
 \ifxjtu@bachelor
+    %根据本科模板重写节标题格式且不影响硕博格式
     \titleformat{\subsection}{\sihao}{\thesubsection}{0.8em}{}
+    \titleformat{\subsubsection}{}{\arabic{subsubsection})~}{0.8em}{}
     \titlespacing{\chapter}{0em}{-1.3\baselineskip}{0.2\baselineskip}
     \ifxjtu@bigskip
       \linespread{1.5} \selectfont

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -496,7 +496,7 @@
 \fi
 
 \ifxjtu@bachelor
-
+    \titleformat{\subsection}{\sihao}{\thesubsection}{0.8em}{}
     \ifxjtu@bigskip
       \linespread{1.5} \selectfont
     \else
@@ -606,7 +606,7 @@
         \mbox{ }
         \begin{spacing}{1.2}%段落行距设置
         {\xiaosi \noindent
-            {\bf KEY WORDS: }
+            {\bf KEY WORDS}: 
             \xjtu@ekeywords
         }
         \end{spacing}

--- a/solutions/bachelor.tex
+++ b/solutions/bachelor.tex
@@ -32,6 +32,7 @@
     pdflinks,
     %colorlinks,
     %compact,
+    %autolineskip, % if set, latex will change lineskip to fill the page or it will strictly follow the set lineskip by default which is more like what Word does
     ]{xjtuthesis}
 
 \graphicspath{{figures/}}

--- a/solutions/doctor.tex
+++ b/solutions/doctor.tex
@@ -31,6 +31,7 @@
     pdflinks,
     %colorlinks,
     %compact,
+    %autolineskip, % if set, latex will change lineskip to fill the page or it will strictly follow the set lineskip by default which is more like what Word does
     ]{xjtuthesis}
 
 \graphicspath{{figures/}}

--- a/solutions/master.tex
+++ b/solutions/master.tex
@@ -31,6 +31,7 @@
     pdflinks,
     %colorlinks,
     %compact,
+    %autolineskip, % if set, latex will change lineskip to fill the page or it will strictly follow the set lineskip by default which is more like what Word does
     ]{xjtuthesis}
 
 \graphicspath{{figures/}}


### PR DESCRIPTION
**Add a option** for user to choose whether the typesetting method stretches line spacing to fill the page or strictly follows the lineskip settings strictly and leaves space at the bottom of the page
- default is leaving space at the bottom of the page, this is what Word will do

**Format changes in Bachelor‘s template**
Also thanks to @YQYANG2233 and @LouSQ17
- Remove bold style from the ":" of “Keyword: "
- Rewrite style of subsection in Bachelor‘s template as the intend width was changed from 2.5 to 2 in 2024
- Adjust the vertical position of \chapter block
- Adjust the vertical position of the double lines in the header
- Adjust the indentation of \subsubsection as #50 mentioned while keep master/doctor's template unchanged