### PR TITLE
根据 2024 届毕设 Word 模板的一些更新

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+0.9.0 (June 4, 2024) (Credit: ShunchiZhang)
+ * `b5b8832` 修正了摘要和致谢中间的空格
+ * `d8e288c` 修正了图序与表序的前后空格
+ * `ea221fa` 修正了附录奇数页页眉
+ * `c12b835` 增加了文末插入 PDF 的功能（任务书等）
+ * `b5b8832` Fixed: spaces between abstract and acknowledgements
+ * `d8e288c` Fixed: spaces before and after figure and table captions
+ * `ea221fa` Fixed: odd page headers in the appendices
+ * `c12b835` Added: feature to append required PDFs
+
 0.8.0 (May 5, 2023) (Credit: junyang-zh)
  * 修改了默认非私有字体为*思源宋体*和*思源黑体*
  * 修改了 Makefile 使其符合 Wiki 描述（`make bachelor`, etc.）

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+0.9.1 (June 4, 2024) (Credit: ShunchiZhang)
+ * `5d9385e` 使用了楷体作为斜体
+ * `8348605` 提供了 `tarbularx` 表格的对齐设置
+ * `3795051` 修正了多行图题与表题的行距设置
+ * `2341b9c` 提供了 `proof` 环境以编写证明
+ * `5d9385e` Improved: Kai font for italic text
+ * `8348605` Added: alignment options for `tabularx`
+ * `3795051` Fixed: line stretch for multi-line figure and table captions
+ * `2341b9c` Added: `proof` environment
+
 0.9.0 (June 4, 2024) (Credit: ShunchiZhang)
  * `b5b8832` 修正了摘要和致谢中间的空格
  * `d8e288c` 修正了图序与表序的前后空格

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -97,7 +97,6 @@
 \setenumerate[2]{\qquad(1),itemindent=\parindent,listparindent=\parindent,itemsep=0ex,partopsep=0pt,parsep=0ex,topsep=0\baselineskip}
 \RequirePackage{pdfpages}
 \RequirePackage{hanging}
-\RequirePackage{xcolor}
 \RequirePackage{gbt7714}
 
 % Code packages

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -530,6 +530,12 @@
     }
     \pagestyle{plain}
 
+    \fancypagestyle{extrapdf}{%
+        \fancyhf{}
+        \fancyfoot[OR,EL]{\xiaowu ~\thepage~}
+        \renewcommand{\headrulewidth}{0pt}
+    }
+
     \DeclareCaptionLabelFormat{tablelabel}{#1#2}
     \DeclareCaptionLabelFormat{figurelabel}{#1\enspace#2}
     \DeclareCaptionFormat{tablecaption}{#1\enspace#3}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -530,6 +530,13 @@
     }
     \pagestyle{plain}
 
+    \DeclareCaptionLabelFormat{tablelabel}{#1#2}
+    \DeclareCaptionLabelFormat{figurelabel}{#1\enspace#2}
+    \DeclareCaptionFormat{tablecaption}{#1\enspace#3}
+    \DeclareCaptionFormat{figurecaption}{#1\quad#3}
+    \captionsetup[table]{format=tablecaption,labelformat=tablelabel}
+    \captionsetup[figure]{format=figurecaption,labelformat=figurelabel}
+
     \type{本科}
     \renewcommand\xjtuchead{
         \thispagestyle{empty}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -79,8 +79,12 @@
 % Math & format packages
 \RequirePackage{amsmath}
 \RequirePackage{amssymb}
+\RequirePackage{amsthm}
 \RequirePackage{indentfirst}
 \RequirePackage{tabularx}
+\newcolumntype{L}{>{\raggedright\arraybackslash}X}  % 左对齐
+\newcolumntype{C}{>{\centering\arraybackslash}X}    % 居中
+\newcolumntype{R}{>{\raggedleft\arraybackslash}X}   % 右对齐
 \RequirePackage{threeparttable}
 \RequirePackage{array}
 \RequirePackage{longtable}
@@ -95,6 +99,10 @@
 \RequirePackage{hanging}
 \RequirePackage{xcolor}
 \RequirePackage{gbt7714}
+
+% Code packages
+\RequirePackage{listings}
+\RequirePackage{xcolor}
 
 % Add spacing before a table
 \RequirePackage{etoolbox}
@@ -118,6 +126,30 @@
 % titleformat
 \RequirePackage{titlesec,titletoc}
 
+% Code environment definition
+\renewcommand{\lstlistingname}{}
+\lstset{
+    language=Python,
+    basicstyle=\ttfamily\small,
+    keywordstyle=\color{blue},
+    stringstyle=\color{red},
+    commentstyle=\color{green},
+    numbers=left,
+    numberstyle=\tiny\color{gray},
+    stepnumber=1,
+    numbersep=5pt,
+    backgroundcolor=\color{white},
+    showspaces=false,
+    showstringspaces=false,
+    showtabs=false,
+    frame=single,
+    tabsize=4,
+    captionpos=t, % Set caption position to top
+    breaklines=true,
+    breakatwhitespace=false,
+    escapeinside={\%*}{*)}
+}
+
 % l10n here
 \renewcommand{\tablename}{表}
 \renewcommand{\figurename}{图}
@@ -133,7 +165,6 @@
 \renewcommand\theequation{%
     \ifnum \c@chapter >\z@ \thechapter-\fi \@arabic \c@equation%
 }
-\captionsetup{labelsep=quad}
 \captionsetup[longtable]{labelsep=quad}
 
 \newcommand{\thesis}{thesis}
@@ -205,8 +236,8 @@
   \abovedisplayshortskip=10bp \@plus 2bp \@minus 2bp
   \belowdisplayskip=\abovedisplayskip
   \belowdisplayshortskip=\abovedisplayshortskip}
-\DeclareCaptionFont{wuhao}{\wuhao}\captionsetup{font=wuhao,labelsep=quad} % thanks to @wanderxjtu
-\DeclareCaptionFont{xiaowu}{\xiaowu}\captionsetup[subfloat]{font=xiaowu} % issue 4
+\DeclareCaptionFont{wuhaostretch}{\setstretch{1.2}\wuhao}\captionsetup{font=wuhaostretch,labelsep=quad} % thanks to @wanderxjtu
+\DeclareCaptionFont{xiaowustretch}{\setstretch{1.2}\xiaowu}\captionsetup[subfloat]{font=xiaowustretch} % issue 4
 
 % Subfloat
 \captionsetup[subfloat]{labelformat=simple,captionskip=6bp,nearskip=6bp,farskip=0bp,topadjust=0bp}
@@ -241,6 +272,18 @@
         \def\CJKmovesymbol#1{\raise.35em\hbox{#1}}
         \def\CJKmove{\let\CJKsymbol\CJKmovesymbol \let\CJKpunctsymbol\CJKsymbol}
     \setCJKfamilyfont{hei}{SimHei}
+    
+    % 对于 Mac 用户：
+    % \setCJKmainfont[
+    %     % AutoFakeBold,                  % 非常不明显
+    %     % BoldFont   = Songti SC Black,  % 相比 Bold 更大的字重，可根据个人喜好选择
+    %     BoldFont   = Songti SC Bold,     % 适中的加粗效果，可以更换为 Black 达到更突出的效果
+    %     ItalicFont = Kaiti SC,
+    % ]{Songti SC}
+    % \setCJKfamilyfont{vert}[AutoFakeBold,RawFeature={script=hani:language=CHN:vertical:+valt}]{Songti SC}
+    %     \def\CJKmovesymbol#1{\raise.35em\hbox{#1}}
+    %     \def\CJKmove{\let\CJKsymbol\CJKmovesymbol \let\CJKpunctsymbol\CJKsymbol}
+    % \setCJKfamilyfont{hei}{Heiti SC}
   \else
     \setmainfont[Ligatures=TeX]{FreeSerif}
     \setCJKmainfont{Source Han Serif CN}
@@ -503,9 +546,13 @@
 
 \ifxjtu@bachelor
     %根据本科模板重写节标题格式且不影响硕博格式
-    \titleformat{\subsection}{\sihao}{\thesubsection}{0.8em}{}
-    \titleformat{\subsubsection}{}{\arabic{subsubsection})~}{0.8em}{}
     \titlespacing{\chapter}{0em}{-1.3\baselineskip}{0.3\baselineskip}
+    \titleformat{\section}[hang]{\xiaosan}{\thesection}{0.3em}{}
+    \titlespacing{\section}{0em}{0.5\baselineskip}{0.5\baselineskip}
+    \titleformat{\subsection}{\sihao}{\thesubsection}{0.3em}{}
+    \titlespacing{\subsection}{2em}{0.4\baselineskip}{0\baselineskip}
+    \titleformat{\subsubsection}{}{\arabic{subsubsection}）}{0.1em}{}
+    \titlespacing{\subsubsection}{2em}{0.1\baselineskip}{0\baselineskip}
     \ifxjtu@bigskip
       \linespread{1.5} \selectfont
     \else
@@ -530,12 +577,15 @@
     }
     \pagestyle{plain}
 
-    \fancypagestyle{extrapdf}{%
+    \fancypagestyle{extrapdf}{% 关闭页眉以使用任务书文件自带页眉
         \fancyhf{}
         \fancyfoot[OR,EL]{\xiaowu ~\thepage~}
         \renewcommand{\headrulewidth}{0pt}
     }
-
+  \def\importsheet#1{
+      \cleardoublepage
+      \includepdf[pages=-,noautoscale=true,offset=0 \voffset, scale=1,pagecommand={\thispagestyle{extrapdf}}]{#1}
+  }
     \DeclareCaptionLabelFormat{tablelabel}{#1#2}
     \DeclareCaptionLabelFormat{figurelabel}{#1\enspace#2}
     \DeclareCaptionFormat{tablecaption}{#1\enspace#3}
@@ -668,7 +718,7 @@
             \pagestyle{plain}
         \fi
         \pagenumbering{arabic}
-        \titleformat{\chapter}[block]{\sanhao}{}{0em}{\begin{center}\thechapter\quad\ \ }[\end{center}]
+        \titleformat{\chapter}[block]{\sanhao}{}{0em}{\begin{center}\thechapter\quad }[\end{center}]
         \xjtu@inmainbodytrue
     }
     \renewcommand\xjtuendcontent{
@@ -1011,6 +1061,7 @@
 \newtheorem{remark}{注释}[chapter]
 \newtheorem{problem}{问题}[chapter]
 \newtheorem{conjecture}{猜想}[chapter]
+\renewenvironment{proof}{\noindent\textbf{证明}：}{\hfill$\blacksquare$}
 
 \RequirePackage[shortlabels]{enumitem}
 \setenumerate[1]{1),fullwidth,itemindent=\parindent,listparindent=\parindent,itemsep=0.05\baselineskip,partopsep=0pt,parsep=0ex,topsep=0.1\baselineskip}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -574,8 +574,8 @@
         \clearpage
     }
     \renewcommand\xjtucinfopage{
-        \addcontentsline{toc}{chapter}{摘要}%尽管摘要存在于目录之前,但2024年模板要求摘要包含在目录中
-        \chaptermark{摘要}
+        \addcontentsline{toc}{chapter}{摘\quad 要}%尽管摘要存在于目录之前,但2024年模板要求摘要包含在目录中
+        \chaptermark{摘\quad 要}
         \makebox{}
         \begin{spacing}{1.2}%段落行距设置
         \begin{center}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -537,6 +537,17 @@
     \captionsetup[table]{format=tablecaption,labelformat=tablelabel}
     \captionsetup[figure]{format=figurecaption,labelformat=figurelabel}
 
+    \renewcommand{\xjtuappendix}{
+        \begin{appendix}
+        \renewcommand{\thechapter}{附录\Alph{chapter}}
+    }
+    \renewcommand{\xjtuappendixchapter}[1]{
+        \stepcounter{chapter}
+        \chapter*{\thechapter\quad#1}
+        \chaptermark{#1}
+        \addcontentsline{toc}{chapter}{\thechapter\quad #1}
+    }
+
     \type{本科}
     \renewcommand\xjtuchead{
         \thispagestyle{empty}

--- a/doc/examples/bachelor.tex
+++ b/doc/examples/bachelor.tex
@@ -71,7 +71,7 @@
 
     \xjtuendappendix
 
-    \xjtuspchapter{致谢}{致\qquad 谢}
+    \xjtuspchapter{致\quad 谢}{致\quad 谢}
 
         \input{pages/anthem.tex}
 

--- a/doc/examples/bachelor.tex
+++ b/doc/examples/bachelor.tex
@@ -75,5 +75,7 @@
 
         \input{pages/anthem.tex}
 
+        \input{pages/extrapdfs.tex}
+
 \end{document}
 

--- a/doc/examples/pages/extrapdfs.tex
+++ b/doc/examples/pages/extrapdfs.tex
@@ -1,0 +1,7 @@
+\iffalse
+\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/任务书.pdf}
+% 使用以下行插入空白页以满足奇数页起排的要求
+% \newpage \ \newpage
+\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/考核评议书.pdf}
+\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/答辩结果.pdf}
+\fi

--- a/solutions/bachelor.tex
+++ b/solutions/bachelor.tex
@@ -77,6 +77,7 @@
 
     \xjtuendappendix
 
+        \input{pages/extrapdfs.tex}
 
 \end{document}
 

--- a/solutions/bachelor.tex
+++ b/solutions/bachelor.tex
@@ -64,7 +64,7 @@
 
     \xjtuendcontent
 
-    \xjtuspchapter{致谢}{致\qquad 谢}
+    \xjtuspchapter{致\quad 谢}{致\quad 谢}
 
         \input{pages/acknowledgements.tex}
 

--- a/solutions/pages/appendice.tex
+++ b/solutions/pages/appendice.tex
@@ -39,4 +39,13 @@
     \xjtuappendixchapter{还是附录}
 
         \xjtuappendixsection{测试}
+
+    \xjtuappendixchapter{关键计算机源程序}
+    \xjtuappendixsection{代码示例}
+        \begin{lstlisting}[language=Python]
+            def hello world():
+                print("Hello, world!")
+        \end{lstlisting}
+    \xjtuappendixsection{外部导入代码示例)
+        \lstinputlisting[language=Python]{statics.py}
 \fi

--- a/solutions/pages/extrapdfs.tex
+++ b/solutions/pages/extrapdfs.tex
@@ -1,7 +1,5 @@
 \iffalse
-\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/任务书.pdf}
-% 使用以下行插入空白页以满足奇数页起排的要求
-% \newpage \ \newpage
-\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/考核评议书.pdf}
-\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/答辩结果.pdf}
+\importsheet{pdfs/任务书.pdf}
+\importsheet{pdfs/考核评议书.pdf}
+\importsheet{pdfs/答辩结果.pdf}
 \fi

--- a/solutions/pages/extrapdfs.tex
+++ b/solutions/pages/extrapdfs.tex
@@ -1,0 +1,7 @@
+\iffalse
+\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/任务书.pdf}
+% 使用以下行插入空白页以满足奇数页起排的要求
+% \newpage \ \newpage
+\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/考核评议书.pdf}
+\includepdf[pages=1-,pagecommand={\thispagestyle{extrapdf}},scale=1.0,offset=0cm \voffset]{pdfs/答辩结果.pdf}
+\fi


### PR DESCRIPTION
注：`>` 中内容均引自《2024届本科毕业设计（论文）模版》

## [`b5b8832`](https://github.com/ShunchiZhang/xjtuthesis/commit/b5b8832) 修正了摘要和致谢中间的空格

> - **摘要**：……居中编排“摘  要”二字（三号宋体），**字间空两个半角字符**……
> - **致谢**：……居中编排“致  谢”二字（三号宋体），**字间空两个半角字符**……

## [`d8e288c`](https://github.com/ShunchiZhang/xjtuthesis/commit/d8e288c) 修正了图序与表序的前后空格

> - 图序前空1字符，图序后空2字符
> - 表序前不空格，表序后空1字

这里没说是全角字符还是半角字符，但模板中实际使用的是半角。

## [`ea221fa`](https://github.com/ShunchiZhang/xjtuthesis/commit/ea221fa) 修正了附录奇数页页眉

> 附录包括：A外文原文、B外文翻译、C有关图纸、D计算机源程序……，此部分内容页眉同上文（**奇数页为一级标题内容**，偶数页为“西安交通大学本科毕业设计（论文）”）

为了不影响硕博格式，仅在 `\ifxjtu@bachelor` 中调整

## [`c12b835`](https://github.com/ShunchiZhang/xjtuthesis/commit/c12b835) 增加了文末插入 PDF 的功能（任务书等）

> 附录后依次编排
> - 《任务书》（双面打印，**奇数页起排**）
> - 《考核评议书》（双面打印，**奇数页起排**，背面是《评审意见书》）
> - 《答辩结果》（**奇数页起排**）
> 此部分内容**不再额外添加“附录X”一级标题**，页眉和排版严格参照模板文件。
> 
> 以上全部内容须与论文装订在一起，**且页码必须接着参考文献的页码连续编写**。
