### PR TITLE
一些可能的 Utils

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+0.9.1 (June 4, 2024) (Credit: ShunchiZhang)
+ * `8348605` 提供了 `tarbularx` 表格的对齐设置
+ * `3795051` 修正了多行图题与表题的行距设置
+ * `2341b9c` 提供了 `proof` 环境以编写证明
+ * `8348605` Added: alignment options for `tabularx`
+ * `3795051` Fixed: line stretch for multi-line figure and table captions
+ * `2341b9c` Added: `proof` environment
+
 0.8.0 (May 5, 2023) (Credit: junyang-zh)
  * 修改了默认非私有字体为*思源宋体*和*思源黑体*
  * 修改了 Makefile 使其符合 Wiki 描述（`make bachelor`, etc.）

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -136,7 +136,6 @@
 \renewcommand\theequation{%
     \ifnum \c@chapter >\z@ \thechapter-\fi \@arabic \c@equation%
 }
-\captionsetup{labelsep=quad}
 \captionsetup[longtable]{labelsep=quad}
 
 \newcommand{\thesis}{thesis}
@@ -208,8 +207,8 @@
   \abovedisplayshortskip=10bp \@plus 2bp \@minus 2bp
   \belowdisplayskip=\abovedisplayskip
   \belowdisplayshortskip=\abovedisplayshortskip}
-\DeclareCaptionFont{wuhao}{\wuhao}\captionsetup{font=wuhao,labelsep=quad} % thanks to @wanderxjtu
-\DeclareCaptionFont{xiaowu}{\xiaowu}\captionsetup[subfloat]{font=xiaowu} % issue 4
+\DeclareCaptionFont{wuhaostretch}{\setstretch{1.2}\wuhao}\captionsetup{font=wuhaostretch,labelsep=quad} % thanks to @wanderxjtu
+\DeclareCaptionFont{xiaowustretch}{\setstretch{1.2}\xiaowu}\captionsetup[subfloat]{font=xiaowustretch} % issue 4
 
 % Subfloat
 \captionsetup[subfloat]{labelformat=simple,captionskip=6bp,nearskip=6bp,farskip=0bp,topadjust=0bp}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -79,6 +79,7 @@
 % Math & format packages
 \RequirePackage{amsmath}
 \RequirePackage{amssymb}
+\RequirePackage{amsthm}
 \RequirePackage{indentfirst}
 \RequirePackage{tabularx}
 \newcolumntype{L}{>{\raggedright\arraybackslash}X}  % 左对齐
@@ -989,6 +990,7 @@
 \newtheorem{remark}{注释}[chapter]
 \newtheorem{problem}{问题}[chapter]
 \newtheorem{conjecture}{猜想}[chapter]
+\renewenvironment{proof}{\noindent\textbf{证明}：}{\hfill$\blacksquare$}
 
 \RequirePackage[shortlabels]{enumitem}
 \setenumerate[1]{1),fullwidth,itemindent=\parindent,listparindent=\parindent,itemsep=0.05\baselineskip,partopsep=0pt,parsep=0ex,topsep=0.1\baselineskip}

--- a/base/xjtuthesis.cls
+++ b/base/xjtuthesis.cls
@@ -81,6 +81,9 @@
 \RequirePackage{amssymb}
 \RequirePackage{indentfirst}
 \RequirePackage{tabularx}
+\newcolumntype{L}{>{\raggedright\arraybackslash}X}  % 左对齐
+\newcolumntype{C}{>{\centering\arraybackslash}X}    % 居中
+\newcolumntype{R}{>{\raggedleft\arraybackslash}X}   % 右对齐
 \RequirePackage{threeparttable}
 \RequirePackage{array}
 \RequirePackage{longtable}


### PR DESCRIPTION
## [`cbcfa27`](https://github.com/ShunchiZhang/xjtuthesis/commit/cbcfa27) 提供了 `tarbularx` 表格的对齐设置

根据《2024届本科毕业设计（论文）模版》：
> 表格必须通栏，即**表格宽度与正文版面平齐**

也就是说必须使用 `tabularx` 实现表格。于是提供了基于 `tabularx` 的左、中、右对齐设置。示例如下：

```latex
\begin{tabularx}{\textwidth}{LCR}
% table here %
\end{tabularx}
```

## [`4109a1e`](https://github.com/ShunchiZhang/xjtuthesis/commit/4109a1e) 修正了多行图题与表题的行距设置

注意到多行图题或表题的情况下，默认行距过小，导致观感十分拥挤，所以使用与其它格式均一致的 1.2 倍行距。

而且前文多了一行 `\captionsetup`，会被后文的覆盖，所以把前文的删除了。

## [`361a37a`](https://github.com/ShunchiZhang/xjtuthesis/commit/361a37a) 提供了 `proof` 环境以编写证明

以无缩进加粗"证明" + 全角冒号开头，以右对齐 QED 标志结尾。
